### PR TITLE
refactor: each method is lighter and do request only.

### DIFF
--- a/betaseries.go
+++ b/betaseries.go
@@ -57,6 +57,24 @@ func NewClient(apiKey string) *Client {
 	return c
 }
 
+func (s *ShowService) doRequest(ctx context.Context, method, urlStr string, params any, response errorableResponse) error {
+	req, err := s.client.newRequest(ctx, method, urlStr, params)
+	if err != nil {
+		return err
+	}
+
+	err = s.client.do(req, response)
+	if err != nil {
+		return err
+	}
+
+	if err = response.GetErrors().Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *Client) newRequest(ctx context.Context, method, url string, params any) (*http.Request, error) {
 	u, err := c.buildURL(url, params)
 	if err != nil {

--- a/data/shows/no_series_found.json
+++ b/data/shows/no_series_found.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "code": 4001,
+      "text": "No series found."
+    }
+  ]
+}

--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,38 @@ import (
 	"fmt"
 )
 
+type errorableResponse interface {
+	GetErrors() Errors
+}
+
+func (s *showsResponse) GetErrors() Errors {
+	return s.Errors
+}
+
+func (s *showResponse) GetErrors() Errors {
+	return s.Errors
+}
+
+func (s *picturesShowResponse) GetErrors() Errors {
+	return s.Errors
+}
+
+func (s *videosShowResponse) GetErrors() Errors {
+	return s.Errors
+}
+
+func (s *charactersShowResponse) GetErrors() Errors {
+	return s.Errors
+}
+
+func (e *episodesResponse) GetErrors() Errors {
+	return e.Errors
+}
+
+func (s *similarsResponse) GetErrors() Errors {
+	return s.Errors
+}
+
 type Error struct {
 	Code    int    `json:"code"`
 	Message string `json:"text"`
@@ -18,10 +50,10 @@ func (errs Errors) Err() error {
 		return nil
 	}
 
-	eb := bytes.NewBuffer(nil)
+	b := bytes.NewBuffer(nil)
 	for _, e := range errs {
-		_, _ = fmt.Fprintf(eb, "Code: %d, Message: %s\n", e.Code, e.Message)
+		_, _ = fmt.Fprintf(b, "Code: %d, Message: %s\n", e.Code, e.Message)
 	}
 
-	return errors.New(eb.String())
+	return errors.New(b.String())
 }

--- a/shows.go
+++ b/shows.go
@@ -195,22 +195,11 @@ type ShowsPicturesParams struct {
 //	}
 //	fmt.Printf("%+v\n", show)
 func (s *ShowService) Display(ctx context.Context, params ShowsDisplayParams) (*Show, error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/shows/display", params)
-	if err != nil {
+	var res showResponse
+	if err := s.doRequest(ctx, http.MethodGet, "/shows/display", params, &res); err != nil {
 		return nil, err
 	}
-
-	var response showResponse
-	err = s.client.do(req, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = response.Errors.Err(); err != nil {
-		return nil, err
-	}
-
-	return &response.Show, nil
+	return &res.Show, nil
 }
 
 // List returns a list of all series.
@@ -227,140 +216,63 @@ func (s *ShowService) Display(ctx context.Context, params ShowsDisplayParams) (*
 //		fmt.Printf("%s\n", show.Title)
 //	}
 func (s *ShowService) List(ctx context.Context, params ShowsListParams) ([]Show, error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/shows/list", params)
-	if err != nil {
+	var res showsResponse
+	if err := s.doRequest(ctx, http.MethodGet, "/shows/list", params, &res); err != nil {
 		return nil, err
 	}
-
-	var response showsResponse
-	err = s.client.do(req, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = response.Errors.Err(); err != nil {
-		return nil, err
-	}
-
-	return response.Shows, nil
+	return res.Shows, nil
 }
 
 // Random returns a list of random series.
 func (s *ShowService) Random(ctx context.Context, params ShowsRandomParams) ([]Show, error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/shows/random", params)
-	if err != nil {
+	var res showsResponse
+	if err := s.doRequest(ctx, http.MethodGet, "/shows/random", params, &res); err != nil {
 		return nil, err
 	}
-
-	var response showsResponse
-	err = s.client.do(req, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = response.Errors.Err(); err != nil {
-		return nil, err
-	}
-
-	return response.Shows, nil
+	return res.Shows, nil
 }
 
 // Episodes returns a list of episodes for the series.
 func (s *ShowService) Episodes(ctx context.Context, params ShowsEpisodesParams) ([]Episode, error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/shows/episodes", params)
-	if err != nil {
+	var res episodesResponse
+	if err := s.doRequest(ctx, http.MethodGet, "/shows/episodes", params, &res); err != nil {
 		return nil, err
 	}
-
-	var response episodesResponse
-	err = s.client.do(req, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = response.Errors.Err(); err != nil {
-		return nil, err
-	}
-
-	return response.Episodes, nil
+	return res.Episodes, nil
 }
 
 // Similars returns a list of characters for the series.
 func (s *ShowService) Similars(ctx context.Context, params ShowsSimilarsParams) ([]SimilarShow, error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/shows/similars", params)
-	if err != nil {
+	var res similarsResponse
+	if err := s.doRequest(ctx, http.MethodGet, "/shows/similars", params, &res); err != nil {
 		return nil, err
 	}
-
-	var response similarsResponse
-	err = s.client.do(req, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = response.Errors.Err(); err != nil {
-		return nil, err
-	}
-
-	return response.Similars, nil
+	return res.Similars, nil
 }
 
 // Videos returns a list of videos for the series.
 func (s *ShowService) Videos(ctx context.Context, params ShowsVideosParams) ([]VideoShow, error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/shows/videos", params)
-	if err != nil {
+	var res videosShowResponse
+	if err := s.doRequest(ctx, http.MethodGet, "/shows/videos", params, &res); err != nil {
 		return nil, err
 	}
-
-	var response videosShowResponse
-	err = s.client.do(req, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = response.Errors.Err(); err != nil {
-		return nil, err
-	}
-
-	return response.Videos, nil
+	return res.Videos, nil
 }
 
 // Characters returns a list of characters for the series.
 func (s *ShowService) Characters(ctx context.Context, params ShowsCharactersParams) ([]CharacterShow, error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/shows/characters", params)
-	if err != nil {
+	var res charactersShowResponse
+	if err := s.doRequest(ctx, http.MethodGet, "/shows/characters", params, &res); err != nil {
 		return nil, err
 	}
-
-	var response charactersShowResponse
-	err = s.client.do(req, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = response.Errors.Err(); err != nil {
-		return nil, err
-	}
-
-	return response.Characters, nil
+	return res.Characters, nil
 }
 
 // Pictures returns a list of pictures for the series.
 func (s *ShowService) Pictures(ctx context.Context, params ShowsPicturesParams) ([]PictureShow, error) {
-	req, err := s.client.newRequest(ctx, http.MethodGet, "/shows/pictures", params)
-	if err != nil {
+	var res picturesShowResponse
+	if err := s.doRequest(ctx, http.MethodGet, "/shows/pictures", params, &res); err != nil {
 		return nil, err
 	}
-
-	var response picturesShowResponse
-	err = s.client.do(req, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = response.Errors.Err(); err != nil {
-		return nil, err
-	}
-
-	return response.Pictures, nil
+	return res.Pictures, nil
 }

--- a/shows_test.go
+++ b/shows_test.go
@@ -85,6 +85,19 @@ func TestShowService_Display(t *testing.T) {
 	}
 }
 
+func TestShowService_DisplayNotFound(t *testing.T) {
+	data, err := os.ReadFile("data/shows/no_series_found.json")
+	assert.NoError(t, err)
+
+	ts, bc := setup(t, fmt.Sprintf("/%s", "shows/display"), string(data))
+	defer ts.Close()
+
+	_, err = bc.Shows.Display(context.Background(), ShowsDisplayParams{})
+	assert.Error(t, err)
+
+	assert.Equal(t, err.Error(), "Code: 4001, Message: No series found.\n")
+}
+
 func TestShowService_List(t *testing.T) {
 	testCases := []struct {
 		url    string
@@ -315,6 +328,19 @@ func TestShowService_Videos(t *testing.T) {
 	assert.Equal(t, 0, video.Episode)
 }
 
+func TestShowService_VideosNotFound(t *testing.T) {
+	data, err := os.ReadFile("data/shows/no_series_found.json")
+	assert.NoError(t, err)
+
+	ts, bc := setup(t, fmt.Sprintf("/%s", "shows/videos"), string(data))
+	defer ts.Close()
+
+	_, err = bc.Shows.Videos(context.Background(), ShowsVideosParams{})
+	assert.Error(t, err)
+
+	assert.Equal(t, err.Error(), "Code: 4001, Message: No series found.\n")
+}
+
 func TestShowService_Characters(t *testing.T) {
 	data, err := os.ReadFile("data/shows/characters.json")
 	assert.NoError(t, err)
@@ -334,6 +360,19 @@ func TestShowService_Characters(t *testing.T) {
 	assert.Equal(t, "Daenerys Targaryen", characters[3].Name)
 	assert.Equal(t, "Emilia Clarke", characters[3].Actor)
 	assert.Equal(t, "https://pictures.betaseries.com/persons/wb8VfDPGpyqcFltnRcJR1Wj3h4Z.jpg", characters[3].Picture)
+}
+
+func TestShowService_CharactersNotFound(t *testing.T) {
+	data, err := os.ReadFile("data/shows/no_series_found.json")
+	assert.NoError(t, err)
+
+	ts, bc := setup(t, fmt.Sprintf("/%s", "shows/characters"), string(data))
+	defer ts.Close()
+
+	_, err = bc.Shows.Characters(context.Background(), ShowsCharactersParams{})
+	assert.Error(t, err)
+
+	assert.Equal(t, err.Error(), "Code: 4001, Message: No series found.\n")
 }
 
 func TestShowService_Pictures(t *testing.T) {
@@ -364,4 +403,17 @@ func TestShowService_Pictures(t *testing.T) {
 	assert.Equal(t, 1080, picture.Height)
 	assert.Equal(t, DateTime(datetime), picture.Date)
 	assert.Equal(t, "none", picture.Picked)
+}
+
+func TestShowService_PicturesNotFound(t *testing.T) {
+	data, err := os.ReadFile("data/shows/no_series_found.json")
+	assert.NoError(t, err)
+
+	ts, bc := setup(t, fmt.Sprintf("/%s", "shows/pictures"), string(data))
+	defer ts.Close()
+
+	_, err = bc.Shows.Pictures(context.Background(), ShowsPicturesParams{})
+	assert.Error(t, err)
+
+	assert.Equal(t, err.Error(), "Code: 4001, Message: No series found.\n")
 }


### PR DESCRIPTION
new `doRequest` method create the request and do request with new errors handler