### PR TITLE
feat: add user info in Show

### DIFF
--- a/data/shows/display_with_token.json
+++ b/data/shows/display_with_token.json
@@ -1,0 +1,202 @@
+{
+  "show": {
+    "id": 807,
+    "thetvdb_id": 95011,
+    "imdb_id": "tt1442437",
+    "themoviedb_id": 1421,
+    "slug": "modernfamily",
+    "title": "Modern Family",
+    "original_title": "Modern Family",
+    "description": "Quand les familles voisines Pritchett, Delgado et Dunphy acceptent qu'un documentaire soit tourné sur leurs vies, elles étaient loin d'imaginer qu'elles allaient tant en révéler... Jay Pritchett a rencontré la très sexy Colombienne Gloria Delgado le jour où sa femme l'a quitté. Leur différence d'âge est pour lui un challenge de tous les jours. Sa fille, Claire, a elle-même bien du mal à gérer sa vie de famille depuis que son mari, Phil, est persuadé d'être en phase avec ses enfants adolescents alors qu'il ne fait que les embarrasser ! Quant au frère de Claire, Mitchell, il vit avec son petit-ami Cameron et ils viennent d'adopter Lily, une petite Vietnamienne...",
+    "seasons": "11",
+    "seasons_details": [
+      {
+        "number": 1,
+        "episodes": 24
+      },
+      {
+        "number": 2,
+        "episodes": 24
+      },
+      {
+        "number": 3,
+        "episodes": 24
+      },
+      {
+        "number": 4,
+        "episodes": 24
+      },
+      {
+        "number": 5,
+        "episodes": 24
+      },
+      {
+        "number": 6,
+        "episodes": 24
+      },
+      {
+        "number": 7,
+        "episodes": 22
+      },
+      {
+        "number": 8,
+        "episodes": 22
+      },
+      {
+        "number": 9,
+        "episodes": 22
+      },
+      {
+        "number": 10,
+        "episodes": 22
+      },
+      {
+        "number": 11,
+        "episodes": 19
+      }
+    ],
+    "episodes": "251",
+    "followers": "45833",
+    "comments": 155,
+    "similars": "34",
+    "characters": "13",
+    "creation": "2009",
+    "showrunner": {
+      "id": "40066",
+      "name": "Steven Levitan",
+      "picture": "https://pictures.betaseries.com/persons/xPT11b4ABpd9idTMBpoaaCH801J.jpg"
+    },
+    "showrunners": [
+      {
+        "id": "36372",
+        "name": "Christopher Lloyd",
+        "slug": "christopher-lloyd",
+        "picture": "https://pictures.betaseries.com/persons/jqdMLOeJvxp9cvJ3jZDtsoCK9fq.jpg"
+      },
+      {
+        "id": "40066",
+        "name": "Steven Levitan",
+        "slug": "steven-levitan",
+        "picture": "https://pictures.betaseries.com/persons/xPT11b4ABpd9idTMBpoaaCH801J.jpg"
+      }
+    ],
+    "genres": {
+      "Comedy": "Comédie"
+    },
+    "length": "21",
+    "network": "ABC (US)",
+    "country": "États-Unis",
+    "rating": "TV-14",
+    "status": "Ended",
+    "language": "en",
+    "notes": {
+      "total": 2788,
+      "mean": 4.4656000000000002359001882723532617092132568359375,
+      "user": 0
+    },
+    "in_account": true,
+    "images": {
+      "show": "https://pictures.betaseries.com/fonds/show/807_1443696312.jpg",
+      "banner": "https://pictures.betaseries.com/fonds/banner/807_1416182400.jpg",
+      "box": "https://pictures.betaseries.com/fonds/box/807_1416182400.jpg",
+      "poster": "https://pictures.betaseries.com/fonds/poster/fc717f69b61a82c0ac9e3ff8cf2d4118.jpg",
+      "clearlogo": {
+        "url": "https://pictures.betaseries.com/clearlogo/en/807_62748562.png",
+        "width": "800",
+        "height": "310"
+      }
+    },
+    "aliases": {
+      "69546": "Família Moderna",
+      "5153": "Famille moderne",
+      "1669": "Modern Family",
+      "22521": "Monguer Family",
+      "22528": "Monguer Family!",
+      "33245": "Uma Família Muito Moderna",
+      "33244": "Współczesna rodzina",
+      "33246": "Американская семейка",
+      "19191": "モダン・ファミリー"
+    },
+    "social_links": [
+      {
+        "type": "facebook",
+        "external_id": "ModernFamily"
+      },
+      {
+        "type": "twitter",
+        "external_id": "ModernFam"
+      },
+      {
+        "type": "instagram",
+        "external_id": "abcmodernfam"
+      }
+    ],
+    "user": {
+      "archived": false,
+      "favorited": false,
+      "remaining": 31,
+      "status": 87.599999999999994315658113919198513031005859375,
+      "last": "S10E09",
+      "tags": "",
+      "next": {
+        "id": 1216277,
+        "code": "S10E10",
+        "date": "2018-12-12",
+        "title": "Stuck in a Moment",
+        "image": "https://pictures.betaseries.com/banners/episodes/807/6821a165cc773d43701513613163faf0.jpg"
+      },
+      "friends_watching": [
+        {
+          "id": 9876,
+          "login": "test user",
+          "note": 5,
+          "avatar": "/images/site/avatar-default.png"
+        }
+      ]
+    },
+    "next_trailer": "x86erwv",
+    "next_trailer_host": "dailymotion",
+    "resource_url": "https://www.betaseries.com/serie/modernfamily",
+    "platforms": {
+      "svods": [
+        {
+          "id": 3,
+          "name": "Prime Video",
+          "tag": null,
+          "color": "#002964",
+          "link_url": "https://www.betaseries.com/link/807/3/fr",
+          "available": {
+            "last": 8,
+            "first": 2
+          },
+          "logo": "https://pictures.betaseries.com/platforms/3.jpg"
+        },
+        {
+          "id": 246,
+          "name": "Disney+",
+          "tag": null,
+          "color": "#080D37",
+          "link_url": "https://www.betaseries.com/link/807/246/fr",
+          "available": {
+            "last": 10,
+            "first": 1
+          },
+          "logo": "https://pictures.betaseries.com/platforms/246.jpg"
+        }
+      ],
+      "svod": {
+        "id": 3,
+        "name": "Prime Video",
+        "tag": null,
+        "color": "#002964",
+        "link_url": "https://www.betaseries.com/link/807/3/fr",
+        "available": {
+          "last": 8,
+          "first": 2
+        },
+        "logo": "https://pictures.betaseries.com/platforms/3.jpg"
+      }
+    }
+  },
+  "errors": []
+}

--- a/shows.go
+++ b/shows.go
@@ -88,6 +88,7 @@ type Show struct {
 	Status         string          `json:"status"`
 	Language       string          `json:"language"`
 	Notes          Note            `json:"notes"`
+	InAccount      bool            `json:"in_account"`
 	Image          struct {
 		Show   string `json:"show"`
 		Banner string `json:"banner"`
@@ -104,6 +105,27 @@ type Show struct {
 		Type       string `json:"type"`
 		ExternalID string `json:"external_id"`
 	} `json:"social_links"`
+	User struct {
+		Archived  bool    `json:"archived"`
+		Favorited bool    `json:"favorited"`
+		Remaining int     `json:"remaining"`
+		Status    float64 `json:"status"`
+		Last      string  `json:"last"`
+		Tags      string  `json:"tags"`
+		Next      struct {
+			ID    *int    `json:"id"`
+			Code  string  `json:"code"`
+			Date  *Date   `json:"date"`
+			Title *string `json:"title"`
+			Image *string `json:"image"`
+		}
+		FriendsWatching []struct {
+			ID     int    `json:"id"`
+			Login  string `json:"login"`
+			Note   *int   `json:"note"`
+			Avatar string `json:"avatar"`
+		} `json:"friends_watching"`
+	}
 	NextTrailer     *string    `json:"next_trailer"`
 	NextTrailerHost *string    `json:"next_trailer_host"`
 	ResourceURL     string     `json:"resource_url"`

--- a/shows_test.go
+++ b/shows_test.go
@@ -108,6 +108,7 @@ func TestShowService_DisplayWithToken(t *testing.T) {
 	assert.Equal(t, Int(1216277), show.User.Next.ID)
 	assert.Equal(t, "S10E10", show.User.Next.Code)
 	assert.Equal(t, "2018-12-12", show.User.Next.Date.String())
+	assert.Equal(t, "test user", show.User.FriendsWatching[0].Login)
 }
 
 func TestShowService_DisplayNotFound(t *testing.T) {

--- a/shows_test.go
+++ b/shows_test.go
@@ -85,6 +85,31 @@ func TestShowService_Display(t *testing.T) {
 	}
 }
 
+func TestShowService_DisplayWithToken(t *testing.T) {
+	data, err := os.ReadFile("data/shows/display_with_token.json")
+	assert.NoError(t, err)
+
+	ts, bc := setup(t, "GET", fmt.Sprintf("/%s", "shows/display?id=807"), string(data))
+	defer ts.Close()
+
+	show, err := bc.Shows.Display(context.Background(), ShowsDisplayParams{
+		ID: Int(807),
+	})
+	assert.NoError(t, err)
+
+	_, err = time.Parse("2006-01-02", show.User.Next.Date.String())
+	assert.NoError(t, err)
+
+	assert.Equal(t, "Modern Family", show.Title)
+	assert.Equal(t, true, show.InAccount)
+	assert.Equal(t, false, show.User.Archived)
+	assert.Equal(t, 87.599999999999994315658113919198513031005859375, show.User.Status)
+	assert.Equal(t, "S10E09", show.User.Last)
+	assert.Equal(t, Int(1216277), show.User.Next.ID)
+	assert.Equal(t, "S10E10", show.User.Next.Code)
+	assert.Equal(t, "2018-12-12", show.User.Next.Date.String())
+}
+
 func TestShowService_DisplayNotFound(t *testing.T) {
 	data, err := os.ReadFile("data/shows/no_series_found.json")
 	assert.NoError(t, err)


### PR DESCRIPTION
If authenticated, `InAccount` and `User` fields will be filled