### PR TITLE
feat: add several endpoints for shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,14 +267,14 @@ func main() {
   - [x] Display the list of all series (GET /shows/list)
   - [x] Display a random series (GET /shows/random)
   - [x] Display episodes of a series (GET /shows/episodes)
-  - [ ] Add a series to the member's account (POST /shows/show) - Token
-  - [ ] Remove a series from the member's account (DELETE /shows/show) - Token
-  - [ ] Archive a series in the member's account (POST /shows/archive) - Token
-  - [ ] Remove a series from the archives of the member's account (DELETE /shows/archive) - Token
+  - [x] Add a series to the member's account (POST /shows/show) - Token
+  - [x] Remove a series from the member's account (DELETE /shows/show) - Token
+  - [x] Archive a series in the member's account (POST /shows/archive) - Token
+  - [x] Remove a series from the archives of the member's account (DELETE /shows/archive) - Token
   - [x] Create a series recommendation from a member to a friend (POST /shows/recommendation) - Token
   - [x] Delete a sent or received series recommendation (DELETE /shows/recommendation) - Token
   - [x] Change the status of a received series recommendation (PUT /shows/recommendation) - Token
-  - [ ] Retrieve recommendations received by the identified user (GET /shows/recommendation) - Token
+  - [x] Retrieve recommendations received by the identified user (GET /shows/recommendation) - Token
   - [x] Retrieve series marked as similar (GET /shows/similars)
   - [x] Retrieve videos associated with the series (GET /shows/videos)
   - [x] Retrieve characters of the series (GET /shows/characters)

--- a/data/shows/add_post.json
+++ b/data/shows/add_post.json
@@ -1,0 +1,73 @@
+{
+  "show": {
+    "id": 2,
+    "thetvdb_id": 80346,
+    "imdb_id": "tt1076180",
+    "themoviedb_id": 6713,
+    "slug": "james-mays-20th-century",
+    "title": "James May's 20th Century",
+    "original_title": "James May's 20th Century",
+    "description": "The world in 1999 would have been unrecognisable to anyone from 1900. James May takes a look at some of the greatest developments of the 20th century, and reveals how they shaped the times we live in now.",
+    "seasons": "1",
+    "seasons_details": [
+      {
+        "number": 1,
+        "episodes": 6
+      }
+    ],
+    "episodes": "6",
+    "followers": "16",
+    "comments": 0,
+    "similars": "0",
+    "characters": "0",
+    "creation": "2007",
+    "showrunner": null,
+    "showrunners": [],
+    "genres": {
+      "Documentary": "Documentaire"
+    },
+    "length": "30",
+    "network": "BBC Two",
+    "country": "Royaume-Uni",
+    "rating": "",
+    "status": "Ended",
+    "language": "en",
+    "notes": {
+      "total": 2,
+      "mean": 4.5,
+      "user": 0
+    },
+    "in_account": true,
+    "images": {
+      "show": "https://pictures.betaseries.com/fonds/show/2_31144.jpg",
+      "banner": "https://pictures.betaseries.com/fonds/banner/2_766861.jpg",
+      "box": "https://pictures.betaseries.com/fonds/box/2_766861.jpg",
+      "poster": null
+    },
+    "aliases": {
+      "43903": "XX век глазами Джеймса Мэя"
+    },
+    "social_links": [],
+    "user": {
+      "archived": false,
+      "favorited": false,
+      "remaining": 3,
+      "status": 50,
+      "last": "S01E03",
+      "tags": "",
+      "next": {
+        "id": 24342,
+        "code": "S01E04",
+        "date": "2007-07-18",
+        "title": "Take cover",
+        "image": "..."
+      },
+      "friends_watching": []
+    },
+    "next_trailer": null,
+    "next_trailer_host": null,
+    "resource_url": "https://www.betaseries.com/serie/james-mays-20th-century",
+    "platforms": null
+  },
+  "errors": []
+}

--- a/data/shows/add_post_already_in_account.json
+++ b/data/shows/add_post_already_in_account.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "code": 2003,
+      "text": "L'utilisateur a déjà cette série dans son compte."
+    }
+  ]
+}

--- a/data/shows/delete_delete.json
+++ b/data/shows/delete_delete.json
@@ -1,0 +1,73 @@
+{
+  "show": {
+    "id": 2,
+    "thetvdb_id": 80346,
+    "imdb_id": "tt1076180",
+    "themoviedb_id": 6713,
+    "slug": "james-mays-20th-century",
+    "title": "James May's 20th Century",
+    "original_title": "James May's 20th Century",
+    "description": "The world in 1999 would have been unrecognisable to anyone from 1900. James May takes a look at some of the greatest developments of the 20th century, and reveals how they shaped the times we live in now.",
+    "seasons": "1",
+    "seasons_details": [
+      {
+        "number": 1,
+        "episodes": 6
+      }
+    ],
+    "episodes": "6",
+    "followers": "17",
+    "comments": 0,
+    "similars": "0",
+    "characters": "0",
+    "creation": "2007",
+    "showrunner": null,
+    "showrunners": [],
+    "genres": {
+      "Documentary": "Documentaire"
+    },
+    "length": "30",
+    "network": "BBC Two",
+    "country": "Royaume-Uni",
+    "rating": "",
+    "status": "Ended",
+    "language": "en",
+    "notes": {
+      "total": 2,
+      "mean": 4.5,
+      "user": 0
+    },
+    "in_account": false,
+    "images": {
+      "show": "https://pictures.betaseries.com/fonds/show/2_31144.jpg",
+      "banner": "https://pictures.betaseries.com/fonds/banner/2_766861.jpg",
+      "box": "https://pictures.betaseries.com/fonds/box/2_766861.jpg",
+      "poster": null
+    },
+    "aliases": {
+      "43903": "XX век глазами Джеймса Мэя"
+    },
+    "social_links": [],
+    "user": {
+      "archived": false,
+      "favorited": false,
+      "remaining": 3,
+      "status": 50,
+      "last": "S01E03",
+      "tags": "",
+      "next": {
+        "id": 24342,
+        "code": "S01E04",
+        "date": "2007-07-17",
+        "title": "Take Cover",
+        "image": "https://pictures.betaseries.com/banners/episodes/80346/332123.jpg"
+      },
+      "friends_watching": []
+    },
+    "next_trailer": null,
+    "next_trailer_host": null,
+    "resource_url": "https://www.betaseries.com/serie/james-mays-20th-century",
+    "platforms": null
+  },
+  "errors": []
+}

--- a/errors.go
+++ b/errors.go
@@ -38,6 +38,10 @@ func (s *similarsResponse) GetErrors() Errors {
 	return s.Errors
 }
 
+func (s *recommendationsResponse) GetErrors() Errors {
+	return s.Errors
+}
+
 func (s *recommendationResponse) GetErrors() Errors {
 	return s.Errors
 }

--- a/recommendations.go
+++ b/recommendations.go
@@ -12,6 +12,11 @@ const (
 
 type RecommendationStatus string
 
+type recommendationsResponse struct {
+	Recommendations []Recommendation `json:"recommendations"`
+	Errors          Errors           `json:"errors"`
+}
+
 type recommendationResponse struct {
 	Recommendation Recommendation `json:"recommendation"`
 	Errors         Errors         `json:"errors"`

--- a/shows.go
+++ b/shows.go
@@ -119,14 +119,14 @@ type Show struct {
 			Date  *Date   `json:"date"`
 			Title *string `json:"title"`
 			Image *string `json:"image"`
-		}
+		} `json:"next"`
 		FriendsWatching []struct {
 			ID     int    `json:"id"`
 			Login  string `json:"login"`
 			Note   *int   `json:"note"`
 			Avatar string `json:"avatar"`
 		} `json:"friends_watching"`
-	}
+	} `json:"user"`
 	NextTrailer     *string    `json:"next_trailer"`
 	NextTrailerHost *string    `json:"next_trailer_host"`
 	ResourceURL     string     `json:"resource_url"`
@@ -195,6 +195,33 @@ type ShowsEpisodesParams struct {
 	Locale    *LocaleType `url:"locale"`
 }
 
+type ShowsAddParams struct {
+	ID        *int        `url:"id"`
+	TheTvdbID *int        `url:"thetvdb_id"`
+	ImdbID    *string     `url:"imdb_id"`
+	EpisodeID *int        `url:"episode_id"`
+	Locale    *LocaleType `url:"locale"`
+}
+
+type ShowsDeleteParams struct {
+	ID        *int        `url:"id"`
+	TheTvdbID *int        `url:"thetvdb_id"`
+	ImdbID    *string     `url:"imdb_id"`
+	Locale    *LocaleType `url:"locale"`
+}
+
+type ShowsArchiveParams struct {
+	ID        *int        `url:"id"`
+	TheTvdbID *int        `url:"thetvdb_id"`
+	Locale    *LocaleType `url:"locale"`
+}
+
+type ShowsUnarchiveParams struct {
+	ID        *int        `url:"id"`
+	TheTvdbID *int        `url:"thetvdb_id"`
+	Locale    *LocaleType `url:"locale"`
+}
+
 type ShowsSimilarsParams struct {
 	ID        *int        `url:"id"`
 	TheTvdbID *int        `url:"thetvdb_id"`
@@ -228,7 +255,7 @@ type ShowsPicturesParams struct {
 	Locale    *LocaleType    `url:"locale"`
 }
 
-type ShowsRecommendationParams struct {
+type ShowsCreateRecommendationParams struct {
 	ID        *int        `url:"id"`
 	TheTvdbID *int        `url:"thetvdb_id"`
 	To        int         `url:"to"`
@@ -244,6 +271,10 @@ type ShowsUpdateRecommendationParams struct {
 
 type ShowsDeleteRecommendationParams struct {
 	ID     int         `url:"id"`
+	Locale *LocaleType `url:"locale"`
+}
+
+type ShowsRecommendationsParams struct {
 	Locale *LocaleType `url:"locale"`
 }
 
@@ -337,6 +368,44 @@ func (s *ShowService) Episodes(ctx context.Context, params ShowsEpisodesParams) 
 	return res.Episodes, nil
 }
 
+// Add add a series to the member's account.
+// Require a valid token.
+func (s *ShowService) Add(ctx context.Context, params ShowsAddParams) (*Show, error) {
+	var res showResponse
+	if err := s.doRequest(ctx, http.MethodPost, "/shows/show", params, &res); err != nil {
+		return nil, err
+	}
+	return &res.Show, nil
+}
+
+// Delete remove a series from the member's account.
+// Require a valid token.
+func (s *ShowService) Delete(ctx context.Context, params ShowsDeleteParams) (*Show, error) {
+	var res showResponse
+	if err := s.doRequest(ctx, http.MethodDelete, "/shows/show", params, &res); err != nil {
+		return nil, err
+	}
+	return &res.Show, nil
+}
+
+// Archive archive a series in the member's account.
+func (s *ShowService) Archive(ctx context.Context, params ShowsArchiveParams) (*Show, error) {
+	var res showResponse
+	if err := s.doRequest(ctx, http.MethodPost, "/shows/archive", params, &res); err != nil {
+		return nil, err
+	}
+	return &res.Show, nil
+}
+
+// Unarchive remove a series from the archives of the member's account.
+func (s *ShowService) Unarchive(ctx context.Context, params ShowsUnarchiveParams) (*Show, error) {
+	var res showResponse
+	if err := s.doRequest(ctx, http.MethodDelete, "/shows/archive", params, &res); err != nil {
+		return nil, err
+	}
+	return &res.Show, nil
+}
+
 // Similars returns a list of characters for the series.
 func (s *ShowService) Similars(ctx context.Context, params ShowsSimilarsParams) ([]SimilarShow, error) {
 	var res similarsResponse
@@ -375,12 +444,22 @@ func (s *ShowService) Pictures(ctx context.Context, params ShowsPicturesParams) 
 
 // CreateRecommendation create a series recommendation from authenticated member to a friend.
 // Require a valid token.
-func (s *ShowService) CreateRecommendation(ctx context.Context, params ShowsRecommendationParams) (*Recommendation, error) {
+func (s *ShowService) CreateRecommendation(ctx context.Context, params ShowsCreateRecommendationParams) (*Recommendation, error) {
 	var res recommendationResponse
 	if err := s.doRequest(ctx, http.MethodPost, "/shows/recommendation", params, &res); err != nil {
 		return nil, err
 	}
 	return &res.Recommendation, nil
+}
+
+// Recommendations returns a list of recommendations send and received for the authenticated member.
+// Require a valid token.
+func (s *ShowService) Recommendations(ctx context.Context, params ShowsRecommendationsParams) ([]Recommendation, error) {
+	var res recommendationsResponse
+	if err := s.doRequest(ctx, http.MethodGet, "/shows/recommendations", params, &res); err != nil {
+		return nil, err
+	}
+	return res.Recommendations, nil
 }
 
 // UpdateRecommendation update the status of a recommendation.


### PR DESCRIPTION
- POST shows/shows add show to member account
- DELETE shows/shows remove show from member account
- POST shows/archive archive a series
- DELETE shows/archive unarchive a series
- GET shows/recommendations list recommendations send and received for authenticated member